### PR TITLE
feat: update S3 bucket module version to 5.4.0 and specify AMI owner for console

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -178,7 +178,7 @@ locals {
 
 data "aws_ami" "console_ami" {
   most_recent = true
-  owners = ["730389100204"]
+  owners      = ["730389100204"]
 
   filter {
     name   = "name"

--- a/aws.tf
+++ b/aws.tf
@@ -5,7 +5,7 @@ provider "aws" {
 # Conditional creation of data bucket
 module "automq_byoc_data_bucket_name" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.1.2"
+  version = "5.4.0"
 
   create_bucket = var.automq_byoc_data_bucket_name == "" ? true : false
   bucket        = "automq-data-${var.automq_byoc_env_id}"
@@ -20,7 +20,7 @@ module "automq_byoc_data_bucket_name" {
 # Conditional creation of ops bucket
 module "automq_byoc_ops_bucket_name" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.1.2"
+  version = "5.4.0"
 
   create_bucket = var.automq_byoc_ops_bucket_name == "" ? true : false
   bucket        = "automq-ops-${var.automq_byoc_env_id}"
@@ -178,6 +178,7 @@ locals {
 
 data "aws_ami" "console_ami" {
   most_recent = true
+  owners = ["730389100204"]
 
   filter {
     name   = "name"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.30"
+      version = "6.8.0"
     }
   }
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/pull/42114
Affected by this issue, there was a similar issue with Moudle before:    
![img_v3_02p5_37c91546-6790-431e-a490-98054306612g](https://github.com/user-attachments/assets/eb8ef9e4-93e1-43d8-9e92-e64ecbec9888)

Currently undergoing repair, specifying the image owner.
