### PR TITLE
feat: add support for additional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ module "automq-byoc" {
 
   # Set the target regionId of aws
   cloud_provider_region                    = "ap-southeast-1"  
+  
+  # Optional: Add additional tags to all resources
+  additional_tags = {
+    Environment = "Production"
+    Project     = "MyProject"
+    Owner       = "TeamA"
+    CostCenter  = "Engineering"
+  }
 }
 
 # Necessary outputs
@@ -246,6 +254,7 @@ output "automq_byoc_instance_id" {
 | <a name="input_automq_byoc_env_console_key_name"></a> [automq_byoc_env_console_key_name](#input_automq_byoc_env_console_key_name) | Specify the key pair name for accessing the AutoMQ BYOC environment console. If not specified, the console will be deployed without a key pair. | `string` | `""` | no |
 | <a name="input_use_custom_ami"></a> [use_custom_ami](#input_use_custom_ami) | The parameter defaults to false, which means a specific AMI is not specified. If you wish to use a custom AMI, set this parameter to true and specify the `automq_byoc_env_console_ami` parameter with your custom AMI ID. | `bool` | `false` | no |
 | <a name="input_automq_byoc_env_console_ami"></a> [automq_byoc_env_console_ami](#input_automq_byoc_env_console_ami) | When the `use_custom_ami` parameter is set to true, this parameter must be set with a custom AMI Name to deploy the AutoMQ console. | `string` | `""` | no |
+| <a name="input_additional_tags"></a> [additional_tags](#input_additional_tags) | Additional tags to apply to all resources created by this module. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/aws.tf
+++ b/aws.tf
@@ -11,10 +11,7 @@ module "automq_byoc_data_bucket_name" {
   bucket        = "automq-data-${var.automq_byoc_env_id}"
   force_destroy = true
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 # Conditional creation of ops bucket
@@ -26,10 +23,7 @@ module "automq_byoc_ops_bucket_name" {
   bucket        = "automq-ops-${var.automq_byoc_env_id}"
   force_destroy = true
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 data "aws_availability_zones" "available_azs" {}
@@ -54,10 +48,7 @@ module "automq_byoc_vpc" {
   enable_nat_gateway = true
   single_nat_gateway = true
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_security_group" "vpc_endpoint_sg" {
@@ -80,11 +71,12 @@ resource "aws_security_group" "vpc_endpoint_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    Name                = "automq-byoc-endpoint-sg-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-endpoint-sg-${var.automq_byoc_env_id}"
+    }
+  )
 }
 
 resource "aws_vpc_endpoint" "ec2_endpoint" {
@@ -98,11 +90,12 @@ resource "aws_vpc_endpoint" "ec2_endpoint" {
 
   private_dns_enabled = true
 
-  tags = {
-    Name                = "automq-byoc-ec2-endpoint-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-ec2-endpoint-${var.automq_byoc_env_id}"
+    }
+  )
 }
 
 resource "aws_vpc_endpoint" "s3_endpoint" {
@@ -117,11 +110,12 @@ resource "aws_vpc_endpoint" "s3_endpoint" {
     module.automq_byoc_vpc[0].private_route_table_ids
   )
 
-  tags = {
-    Name                = "automq-byoc-s3-endpoint-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-s3-endpoint-${var.automq_byoc_env_id}"
+    }
+  )
 }
 
 resource "aws_vpc_endpoint" "s3table_endpoint" {
@@ -135,11 +129,12 @@ resource "aws_vpc_endpoint" "s3table_endpoint" {
 
   private_dns_enabled = true
 
-  tags = {
-    Name                = "automq-byoc-ec2-endpoint-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-s3table-endpoint-${var.automq_byoc_env_id}"
+    }
+  )
 }
 
 resource "aws_vpc_endpoint" "glue_endpoint" {
@@ -153,11 +148,12 @@ resource "aws_vpc_endpoint" "glue_endpoint" {
 
   private_dns_enabled = true
 
-  tags = {
-    Name                = "automq-byoc-ec2-endpoint-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-glue-endpoint-${var.automq_byoc_env_id}"
+    }
+  )
 }
 
 locals {
@@ -166,6 +162,15 @@ locals {
   automq_data_bucket                       = var.automq_byoc_data_bucket_name == "" ? module.automq_byoc_data_bucket_name.s3_bucket_id : "${var.automq_byoc_data_bucket_name}"
   automq_ops_bucket                        = var.automq_byoc_ops_bucket_name == "" ? module.automq_byoc_ops_bucket_name.s3_bucket_id : "${var.automq_byoc_ops_bucket_name}"
   zone_id                                  = aws_route53_zone.private_r53.zone_id
+
+  # Common tags that will be applied to all resources
+  common_tags = merge(
+    {
+      automqVendor        = "automq"
+      automqEnvironmentID = var.automq_byoc_env_id
+    },
+    var.additional_tags
+  )
 }
 
 data "aws_vpc" "vpc_id" {
@@ -211,10 +216,7 @@ resource "aws_security_group" "automq_byoc_console_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_role" "automq_byoc_role" {
@@ -234,10 +236,7 @@ resource "aws_iam_role" "automq_byoc_role" {
     ]
   })
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_policy" "automq_byoc_policy" {
@@ -249,10 +248,7 @@ resource "aws_iam_policy" "automq_byoc_policy" {
     automq_ops_bucket  = local.automq_ops_bucket
   })
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_policy" "automq_byoc_k8s_policy" {
@@ -264,10 +260,7 @@ resource "aws_iam_policy" "automq_byoc_k8s_policy" {
     automq_ops_bucket  = local.automq_ops_bucket
   })
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_iam_role_policy_attachment" "automq_byoc_role_attachment_k8s" {
@@ -284,10 +277,7 @@ resource "aws_iam_instance_profile" "automq_byoc_instance_profile" {
   name = "automq-byoc-instance-profile-${var.automq_byoc_env_id}"
   role = aws_iam_role.automq_byoc_role.name
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_route53_zone" "private_r53" {
@@ -301,18 +291,12 @@ resource "aws_route53_zone" "private_r53" {
     create_before_destroy = true
   }
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_eip" "web_ip" {
   instance = aws_instance.automq_byoc_console.id
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags     = local.common_tags
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,12 @@ resource "aws_instance" "automq_byoc_console" {
 
   key_name = var.automq_byoc_env_console_key_name
 
-  tags = {
-    Name                = "automq-byoc-console-${var.automq_byoc_env_id}"
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "automq-byoc-console-${var.automq_byoc_env_id}"
+    }
+  )
 
   associate_public_ip_address = true
 
@@ -38,10 +39,7 @@ resource "aws_ebs_volume" "data_volume" {
   size              = 20
   type              = "gp3"
 
-  tags = {
-    automqVendor        = "automq"
-    automqEnvironmentID = var.automq_byoc_env_id
-  }
+  tags = local.common_tags
 }
 
 resource "aws_volume_attachment" "data_volume_attachment" {

--- a/variables.tf
+++ b/variables.tf
@@ -77,3 +77,9 @@ variable "automq_byoc_env_console_ami" {
   type        = string
   default     = ""
 }
+
+variable "additional_tags" {
+  description = "Additional tags to apply to all resources created by this module."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
- Add additional_tags variable to allow external tag specification
- Implement common_tags local variable to merge default and additional tags
- Update all resources to use centralized tag management
- Add usage example in README for additional_tags feature

This enables users to add custom tags like Environment, Project, Owner, etc. to all AWS resources created by this module.